### PR TITLE
#162412865 Validated that a user can delete own record.

### DIFF
--- a/app/api/v2/models/incident.py
+++ b/app/api/v2/models/incident.py
@@ -135,7 +135,7 @@ class Incident(Model):
         Update
         :return:
         """
-        print(data)
+        # print(data)
         self.id = data[0]
         self.user_id = data[1],
         self.title = data[2]

--- a/app/api/v2/models/user.py
+++ b/app/api/v2/models/user.py
@@ -165,14 +165,15 @@ class User(Model):
 
     def map_user(self, data):
         """ map user to user object"""
+        # print(data)
         self.id = data[0]
         self.username = data[1]
         self.password = data[2]
         self.firstname = data[3]
         self.lastname = data[4]
-        self.phonenumber = data[5]
+        self.othernames = data[5]
         self.email = data[6]
-        self.othernames = data[7]
+        self.phonenumber = data[7]
         self.is_admin = data[8]
 
         return self

--- a/app/tests/v2/base_test.py
+++ b/app/tests/v2/base_test.py
@@ -156,6 +156,18 @@ class BaseTest(TestCase):
                                    "Authorization": f"Bearer {token}"})
         return r
 
+    def admin_create_incident(self):
+        """
+        Create new incident function
+        :return: response
+        """
+        token = self.admin_login()
+        r = self.app.post("/api/v2/interventions",
+                          data=json.dumps(self.incident),
+                          headers={"content-type": "application/json",
+                                   "Authorization": f"Bearer {token}"})
+        return r
+
     def create_new_incident(self):
         """
         Create new incident function

--- a/app/tests/v2/system/test_records.py
+++ b/app/tests/v2/system/test_records.py
@@ -1,9 +1,6 @@
 import json
 import os
-from io import BytesIO
-
 from flask import current_app
-
 from app.tests.v2.base_test import BaseTest
 
 
@@ -187,6 +184,25 @@ class RecordTest(BaseTest):
                                  "id": 1,
                                  "message": "Incident record has been deleted."
                              }]},
+                             json.loads(r.data))
+
+    def test_delete_specific_record_not_allowed(self):
+        """
+        Test if successfully deleted
+        :return: status_code 200
+        """
+        r = self.admin_create_incident()
+        self.assertEqual(r.status_code, 201)
+        token = self.get_token_on_user_login()
+        r = self.app.delete("/api/v2/interventions/1",
+                            headers={"Authorization": f"Bearer {token}"})
+
+        self.assertEqual(r.status_code, 401)
+        self.assertDictEqual({"status": 401,
+                              "message": "Unauthorized action.A user a can "
+                                         "only delete the incident record he/she"
+                                         " created."
+                              },
                              json.loads(r.data))
 
     def test_deleting_specific_record_not_found(self):


### PR DESCRIPTION
#### What does this PR do?
Validates that only an incident creator or admin can delete an incident
#### Description of Task to be completed?
Only the user who created the red-flag or incident record can delete the record.
Test API endpoint user can patch an existing incident.
 create API endpoint.
Should upload images
#### How should this be manually tested?
Clone the repo as bellow:
 ```
 git clone -b ft-user-can-delete-own-record-162412865 git@github.com: bl4ck4ndbr0wn/iReporter.git
```
Create a virtual environment and activate it
 ```
 python3 - m venv env
 source .env
 ```
 Install all the dependencies needed by
 ```
 pip install - r requirements.txt
 ```
 Run the flask application
 ```
  flask run
 ```
On Postman request either of the two endpoints updating as the api requests.
DELETE  /interventions/<red-flag-id>


#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
 [  # 162412865](https://www.pivotaltracker.com/n/projects/2226962)
#### Screenshots (if appropriate)
#### Questions: